### PR TITLE
翻訳したテキストをクリップボードにコピー

### DIFF
--- a/lib/views/text_field_item_view.dart
+++ b/lib/views/text_field_item_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 
 enum Language {
   english,
@@ -54,6 +55,7 @@ class TextFieldItemView extends StatelessWidget {
         text: textEditingController.text,
       ),
     );
+    Fluttertoast.showToast(msg: 'コピーしました');
   }
 
   @override

--- a/lib/views/text_field_item_view.dart
+++ b/lib/views/text_field_item_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 enum Language {
   english,
@@ -36,6 +37,14 @@ class TextFieldItemView extends StatelessWidget {
   final TextEditingController textEditingController;
   final Language language;
 
+  void _copyClipBoard() {
+    Clipboard.setData(
+      ClipboardData(
+        text: textEditingController.text,
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -71,19 +80,9 @@ class TextFieldItemView extends StatelessWidget {
                 ),
               ),
               IconButton(
-                onPressed: () {
-                  // TODO: 音声読み上げ機能を実装
-                },
+                onPressed: _copyClipBoard,
                 icon: const Icon(
-                  Icons.headphones_outlined,
-                ),
-              ),
-              IconButton(
-                onPressed: () {
-                  // TODO: 音声入力機能を実装
-                },
-                icon: const Icon(
-                  Icons.mic_none,
+                  Icons.copy_outlined,
                 ),
               ),
             ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
   translator: ^0.1.7
+  fluttertoast: ^8.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 概要
翻訳したテキストをクリップボードにコピーする実装を行いました。

## インストール
```
flutter pub get
```

## 実装したこと
* コピーボタンをタップで翻訳されたテキストをコピー
* テキストがコピーされたタイミングでトーストを表示

## UI
<img src="https://user-images.githubusercontent.com/82624334/204000841-f3812e39-61f8-48f5-a557-dbd654697005.png" width="300">
